### PR TITLE
Update client version

### DIFF
--- a/archipelago-client/ArchipelagoInterface.cpp
+++ b/archipelago-client/ArchipelagoInterface.cpp
@@ -80,7 +80,7 @@ BOOL CArchipelago::Initialise(std::string URI) {
 	ap->set_room_info_handler([]() {
 		std::list<std::string> tags;
 		if (GameHook->dIsDeathLink) { tags.push_back("DeathLink"); }
-		ap->ConnectSlot(Core->pSlotName, Core->pPassword, 5, tags, { 0,3,7 });
+		ap->ConnectSlot(Core->pSlotName, Core->pPassword, 5, tags, { 0,4,2 });
 		});
 
 	ap->set_items_received_handler([](const std::list<APClient::NetworkItem>& items) {


### PR DESCRIPTION
Now that the [new AP changes](https://github.com/ArchipelagoMW/Archipelago/pull/1864) are merged, this is just a reminder that the reported client version needs to be brought up to date.